### PR TITLE
Avoid  NPE as specified in twitch4j/twitch4j#45

### DIFF
--- a/src/main/java/de/btobastian/sdcf4j/TwitchCommand.java
+++ b/src/main/java/de/btobastian/sdcf4j/TwitchCommand.java
@@ -27,7 +27,7 @@ public @interface TwitchCommand {
      *
      * @return The commands the executor should listen to.
      */
-    String[] aliases();
+    String[] aliases() default {};
 
     /**
      * Gets the description of the command.


### PR DESCRIPTION
Non-initialized array might produce NPE in certain cases 